### PR TITLE
Add a function to disable default console logger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /src
 COPY package*.json ./
 
 RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > /.npmrc
-RUN npm audit
 RUN npm ci
 RUN rm -f /.npmrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.13.0-alpine3.9
+FROM node:12.18.2-alpine
 
 ARG NPM_TOKEN
 

--- a/README.md
+++ b/README.md
@@ -86,3 +86,17 @@ log.error(new Error('some error'))
 
 > A more complex example can be found at [`examples/sentry.js`](examples/sentry.js)
 > which shows how to do a very simple implementation with Sentry.
+
+## Default console logger
+
+By default, the logger will log everything to the console, but this functionality
+can be disabled by running the following on the base logger:
+
+```javascript
+const log = require('@miroculus/log')
+
+log.disableDefaultConsoleLogger()
+```
+
+This is useful to be able to define a custom console logger using the
+[Logging Triggers](#logging-triggers), or disable the console logger altogether.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ can be disabled by running the following on the base logger:
 const log = require('@miroculus/log')
 
 log.disableDefaultConsoleLogger()
+
+// To re-enable the default listener:
+log.enableDefaultConsoleLogger()
 ```
 
 This is useful to be able to define a custom console logger using the

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm i @miroculus/log
 ## Getting Started
 
 By default, the library will log everything to the console, including the log
-level and a timestamp:
+level:
 
 ```javascript
 const log = require('@miroculus/log')
@@ -68,7 +68,7 @@ log.info('another message')
 ## Logging Triggers
 
 If you want to execute some callback everytime a log is emitted, you can listen
-to the the event `log`, e.g:
+to the event `log`, e.g:
 
 ```javascript
 const log = require('@miroculus/log')

--- a/index.js
+++ b/index.js
@@ -168,10 +168,16 @@ const consoleFnMap = {
   debug: 'debug'
 }
 
-baseLogger.on('log', function consoleLogger ({ level, scopes, args }) {
+function consoleLogger ({ level, scopes, args }) {
   const scope = scopes.length > 0 ? `[${scopes.join('][')}]` : ''
   const prefix = `[${level.toUpperCase()}]${scope}`
   console[consoleFnMap[level]](prefix, ...args)
-})
+}
+
+baseLogger.on('log', consoleLogger)
+
+baseLogger.disableDefaultConsoleLogger = () => {
+  baseLogger.removeListener('log', consoleLogger)
+}
 
 module.exports = baseLogger

--- a/index.js
+++ b/index.js
@@ -174,10 +174,16 @@ function consoleLogger ({ level, scopes, args }) {
   console[consoleFnMap[level]](prefix, ...args)
 }
 
-baseLogger.on('log', consoleLogger)
-
 baseLogger.disableDefaultConsoleLogger = () => {
   baseLogger.removeListener('log', consoleLogger)
 }
+
+baseLogger.enableDefaultConsoleLogger = () => {
+  if (!baseLogger.listeners('log').includes(consoleLogger)) {
+    baseLogger.on('log', consoleLogger)
+  }
+}
+
+baseLogger.enableDefaultConsoleLogger()
 
 module.exports = baseLogger

--- a/index.test.js
+++ b/index.test.js
@@ -103,4 +103,21 @@ describe('@miroculus/log', function () {
       })
     })
   })
+
+  describe('.disableDefaultConsoleLogger()', function () {
+    test('should disable default logging to the console', function () {
+      log.disableDefaultConsoleLogger()
+
+      log.critical('some logging message')
+      log.error('some logging message')
+      log.warn('some logging message')
+      log.info('some logging message')
+      log.debug('some logging message')
+
+      expect(consoleSpy.error).toHaveBeenCalledTimes(0)
+      expect(consoleSpy.warn).toHaveBeenCalledTimes(0)
+      expect(consoleSpy.log).toHaveBeenCalledTimes(0)
+      expect(consoleSpy.debug).toHaveBeenCalledTimes(0)
+    })
+  })
 })

--- a/index.test.js
+++ b/index.test.js
@@ -104,20 +104,50 @@ describe('@miroculus/log', function () {
     })
   })
 
-  describe('.disableDefaultConsoleLogger()', function () {
-    test('should disable default logging to the console', function () {
-      log.disableDefaultConsoleLogger()
-
+  describe('default console logger', function () {
+    const logMessages = () => {
       log.critical('some logging message')
       log.error('some logging message')
       log.warn('some logging message')
       log.info('some logging message')
       log.debug('some logging message')
+    }
+
+    test('should disable default logging to the console', function () {
+      log.disableDefaultConsoleLogger()
+
+      logMessages()
 
       expect(consoleSpy.error).toHaveBeenCalledTimes(0)
       expect(consoleSpy.warn).toHaveBeenCalledTimes(0)
       expect(consoleSpy.log).toHaveBeenCalledTimes(0)
       expect(consoleSpy.debug).toHaveBeenCalledTimes(0)
+    })
+
+    test('should re-enable default logging to the console', function () {
+      log.disableDefaultConsoleLogger()
+      log.enableDefaultConsoleLogger()
+
+      logMessages()
+
+      expect(consoleSpy.error).toHaveBeenCalledTimes(2)
+      expect(consoleSpy.warn).toHaveBeenCalledTimes(1)
+      expect(consoleSpy.log).toHaveBeenCalledTimes(1)
+      expect(consoleSpy.debug).toHaveBeenCalledTimes(1)
+    })
+
+    test('should re-enable default logging to the console only once', function () {
+      log.disableDefaultConsoleLogger()
+      log.enableDefaultConsoleLogger()
+      log.enableDefaultConsoleLogger()
+      log.enableDefaultConsoleLogger()
+
+      logMessages()
+
+      expect(consoleSpy.error).toHaveBeenCalledTimes(2)
+      expect(consoleSpy.warn).toHaveBeenCalledTimes(1)
+      expect(consoleSpy.log).toHaveBeenCalledTimes(1)
+      expect(consoleSpy.debug).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/index.test.js
+++ b/index.test.js
@@ -5,7 +5,7 @@ const log = require('.')
 describe('@miroculus/log', function () {
   let consoleSpy
   let logMock
-  const time = 1593096750491
+  const time = Date.now()
 
   beforeAll(() => {
     consoleSpy = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@miroculus/log",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -974,9 +974,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.3.tgz",
-      "integrity": "sha512-v89ga1clpVL/Y1+YI0eIu1VMW+KU7Xl8PhylVtDKVWaSUHBHYPLXMQGBdrpHewaKoTvlXkksbYqPgz8b4cmRZg==",
+      "version": "26.0.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.4.tgz",
+      "integrity": "sha512-4fQNItvelbNA9+sFgU+fhJo8ZFF+AS4Egk3GWwCW2jFtViukXbnztccafAdLhzE/0EiCogljtQQXP8aQ9J7sFg==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",
@@ -1069,9 +1069,9 @@
       }
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
+      "version": "14.0.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.19.tgz",
+      "integrity": "sha512-yf3BP/NIXF37BjrK5klu//asUWitOEoUP5xE1mhSUjazotwJ/eJDgEmMQNlOeWOVv72j24QQ+3bqXHE++CFGag==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miroculus/log",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Node.js log library",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "homepage": "https://github.com/miroculus/log#readme",
   "dependencies": {},
   "devDependencies": {
-    "@types/jest": "26.0.3",
-    "@types/node": "14.0.14",
+    "@types/jest": "26.0.4",
+    "@types/node": "14.0.19",
     "jest": "26.1.0",
     "pre-commit": "1.2.2",
     "standard": "14.3.4"


### PR DESCRIPTION
By default, the logger will log everything to the console, but this functionality
can be disabled by running the following on the base logger:

```javascript
const log = require('@miroculus/log')

log.disableDefaultConsoleLogger()
```

This is useful to be able to define a custom console logger using the
[Logging Triggers](#logging-triggers), or disable the console logger altogether.
